### PR TITLE
MTL style runLogT

### DIFF
--- a/hs-arbor-logger.cabal
+++ b/hs-arbor-logger.cabal
@@ -18,7 +18,11 @@ library
   build-depends:       base >= 4.7 && < 5
                      , bytestring
                      , fast-logger
+                     , lifted-base
                      , monad-logger
+                     , transformers
+                     , transformers-base
+                     , monad-control
                      , text
   default-language:    Haskell2010
 


### PR DESCRIPTION
## Changes

- Added composable and MTL-friendly `runLogT`