### PR TITLE
Re-export useful stuff

### DIFF
--- a/src/Arbor/Logger.hs
+++ b/src/Arbor/Logger.hs
@@ -12,7 +12,9 @@
 
 module Arbor.Logger
 ( runLogT, runLogT'
-, logDebug, logInfo, logWarn, logError)
+, logDebug, logInfo, logWarn, logError
+, MonadLogger(..), LogLevel(..), LoggingT(..)
+)
 where
 
 import           Control.Exception.Lifted    (bracket)


### PR DESCRIPTION
## Changes

- Re-export classes and common types so I don't have to import `Control.Monad.Logger` all the time